### PR TITLE
Feature: Support for custom path in Path particles

### DIFF
--- a/docs/examples/bubbleStream2DPath.html
+++ b/docs/examples/bubbleStream2DPath.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-		<title>Bubble Stream (custom path following)</title>
-		<meta name="description" content="bubble stream - custom path">
+		<title>Bubble Stream (2D path following)</title>
+		<meta name="description" content="bubble stream - 2D path">
 		<link rel="stylesheet" href="css/main.css">
 
 		<!-- Required dependencies -->
@@ -55,11 +55,11 @@
 						"max": 20
 					},
 					"lifetime": {
-						"min": 1.8,
-						"max": 2
+						"min": 2.5,
+						"max": 3
 					},
 					"blendMode": "normal",
-					"frequency": 0.1,
+					"frequency": 0.05,
 					"emitterLifetime": 0,
 					"maxParticles": 500,
 					"pos": {
@@ -70,7 +70,7 @@
 					"spawnType": "point",
 					"extraData":
 					{
-						"path": function (x) { return x; }
+						"path": figureOf8
 					}
 				},
 				//tell the particle example to use PIXI.particles.PathParticle
@@ -85,23 +85,30 @@
 				window.emitter.pathFunction = pathsArray[randInt];
 			});
 
-			var pathsArray = [easing_bounceIn, easing_bounceOut, easing_quarticOut];
-
-			function easing_bounceIn(k)	{ return 1 - easing_bounceOut(1- k);	}
-			function easing_bounceOut(k)
+			var pathsArray = [ArchimedeanSpiral, figureOf8, eye];
+			function ArchimedeanSpiral(t)
 			{
-				k /= 30;
-				if (k < (1 / 2.75)) {
-				    return 7.5625 * k * k;
-				} else if (k < (2 / 2.75)) {
-				    return 7.5625 * (k -= (1.5 / 2.75)) * k + 0.75;
-				} else if (k < (2.5 / 2.75)) {
-				    return 7.5625 * (k -= (2.25 / 2.75)) * k + 0.9375;
-				} else {
-				    return 7.5625 * (k -= (2.625 / 2.75)) * k + 0.984375;
-				}
+				t /= 10;
+				var velocity = 5, angularVel = 0.3;
+				var x = velocity * t * Math.cos(angularVel * t);
+				var y = velocity * t * Math.sin(angularVel * t);
+				return {x, y};
 			}
-			function easing_quarticOut(k) {	k /= 30; return 1 - (--k * k * k * k); }
+			function figureOf8(t)
+			{
+				t /= 25;
+				var parameter = 120;
+				var x = parameter * Math.sin(t);
+				var y = x * Math.cos(t);
+				return {x, y};
+			}
+			function eye(t)
+			{
+				t /= 50;
+				var x = 100 * Math.pow(Math.sin(t), 3) + 200;
+				var y = 200 * Math.cos(t) - 5 * Math.cos(2*t) - 2*Math.cos(3*t) - Math.cos(4*t) + 20;
+				return {x,y};
+			}
 		</script>
 	</body>
 </html>

--- a/docs/examples/bubbleStream2DPath.html
+++ b/docs/examples/bubbleStream2DPath.html
@@ -105,8 +105,8 @@
 			function eye(t)
 			{
 				t /= 50;
-				var x = 100 * Math.pow(Math.sin(t), 3) + 200;
-				var y = 200 * Math.cos(t) - 5 * Math.cos(2*t) - 2*Math.cos(3*t) - Math.cos(4*t) + 20;
+				var x = 100 * Math.pow(Math.sin(t), 3);
+				var y = 200 * Math.cos(t) - 5 * Math.cos(2*t) - 2*Math.cos(3*t) - Math.cos(4*t);
 				return {x,y};
 			}
 		</script>

--- a/docs/examples/bubbleStreamCustomPath.html
+++ b/docs/examples/bubbleStreamCustomPath.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html class="no-js">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<title>Bubble Stream (path following)</title>
+		<meta name="description" content="bubble stream">
+		<link rel="stylesheet" href="css/main.css">
+
+		<!-- Required dependencies -->
+		<script src="libs/pixi.js/dist/pixi.js"></script>
+		<script src="../dist/pixi-particles.js"></script>
+
+		<!-- Example scaffolding -->
+		<script src="js/ParticleExample.js"></script>
+
+	</head>
+	<body>
+		<div id="framerate"></div>
+		<div id="instructions">Click Anywhere</div>
+		<canvas id="stage" width="400" height="400"></canvas>
+		<script>
+
+			// See js/ParticleExample.js for actual setup
+			new ParticleExample(
+				// The image to use
+				["images/Bubbles99.png"],
+
+				// Emitter configuration, edit this to change the look
+				// of the emitter
+				{
+					"alpha": {
+						"start": 1,
+						"end": 0.16
+					},
+					"scale": {
+						"start": 0.3,
+						"end": 0.4,
+						"minimumScaleMultiplier":0.5
+					},
+					"color": {
+						"start": "ffffff",
+						"end": "ffffff"
+					},
+					"speed": {
+						"start": 150,
+						"end": 100
+					},
+					"startRotation": {
+						"min": 270,
+						"max": 270
+					},
+					"rotationSpeed": {
+						"min": 0,
+						"max": 20
+					},
+					"lifetime": {
+						"min": 1.8,
+						"max": 2
+					},
+					"blendMode": "normal",
+					"frequency": 0.1,
+					"emitterLifetime": 0,
+					"maxParticles": 500,
+					"pos": {
+						"x": 0,
+						"y": 0
+					},
+					"addAtBack": false,
+					"spawnType": "point",
+					"extraData":
+					{
+						"path": function (x) { return x; }
+					}
+				},
+				//tell the particle example to use PIXI.particles.PathParticle
+				"path");
+
+			var canvas = document.getElementById("stage");
+			canvas.addEventListener('mouseup', function(e){
+				if(!(window.emitter && window.emitter.pathFunction)) return;
+				
+				// on each click, select a random path function.
+				var randInt = Math.floor(Math.random() * pathsArray.length);
+				window.emitter.pathFunction = pathsArray[randInt];
+			});
+
+			var pathsArray = [easing_bounceIn, easing_bounceOut, easing_quarticOut];
+
+			function easing_bounceIn(k)	{ return 1 - easing_bounceOut(1- k);	}
+			function easing_bounceOut(k)
+			{
+				k /= 30;
+				if (k < (1 / 2.75)) {
+				    return 7.5625 * k * k;
+				} else if (k < (2 / 2.75)) {
+				    return 7.5625 * (k -= (1.5 / 2.75)) * k + 0.75;
+				} else if (k < (2.5 / 2.75)) {
+				    return 7.5625 * (k -= (2.25 / 2.75)) * k + 0.9375;
+				} else {
+				    return 7.5625 * (k -= (2.625 / 2.75)) * k + 0.984375;
+				}
+			}
+			function easing_quarticOut(k) {	k /= 30; return 1 - (--k * k * k * k); }
+		</script>
+	</body>
+</html>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -28,6 +28,8 @@
 				<li><a href="bubbleSpray.html">Bubble Spray</a></li>
 				<li><a href="bubbleStream.html">Bubble Stream</a></li>
 				<li><a href="bubbleStreamPath.html">Bubble Stream (path following)</a></li>
+				<li><a href="bubbleStreamCustomPath.html">Bubble Stream (custom path following)</a></li>
+				<li><a href="bubbleStream2DPath.html">Bubble Stream (2D path following)</a></li>
 				<li><a href="bubblesVertical.html">Vertical Bubbles</a></li>
 				<li><a href="cartoonSmoke.html">Cartoon Smoke</a></li>
 				<li><a href="cartoonSmoke2.html">Cartoon Smoke Alt.</a></li>

--- a/docs/examples/js/ParticleExample.js
+++ b/docs/examples/js/ParticleExample.js
@@ -160,6 +160,7 @@
 			};
 
 			window.emitter = emitter;
+			window.stage = stage;
 		});
 	};
 

--- a/docs/examples/js/ParticleExample.js
+++ b/docs/examples/js/ParticleExample.js
@@ -158,6 +158,8 @@
 
 				renderer.render(stage);
 			};
+
+			window.emitter = emitter;
 		});
 	};
 

--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -5,6 +5,7 @@ import {PolygonalChain} from "./PolygonalChain";
 import {EmitterConfig, OldEmitterConfig} from "./EmitterConfig";
 import {Point, Circle, Rectangle, Container, settings} from "pixi.js";
 import * as pixi from "pixi.js";
+import { IPathFunction, PathParticle } from "./PathParticle";
 // get the shared ticker, in V4 and V5 friendly methods
 /**
  * @hidden
@@ -758,6 +759,28 @@ export class Emitter
 			ticker.add(this.update, this);
 		}
 		this._autoUpdate = !!value;
+	}
+
+	/**
+	 * Gets or sets the path function.
+	 * This is only applicable for Path particles. Otherwise returns `null`.
+	 * @example
+	 * ```ts
+	 * emitter.pathFunction = function(x){ return x * 10; }
+	 * ```
+	 */
+	public get pathFunction(): IPathFunction
+	{
+		if (this._particleConstructor == PathParticle) 
+		{
+			return (this.extraData && this.extraData.path) ? this.extraData.path : null;
+		}
+		return null;
+	}
+	public set pathFunction(customFunc: IPathFunction)
+	{
+		this.extraData = this.extraData || {};
+		this.extraData.path = customFunc;
 	}
 
 	/**

--- a/src/PathParticle.ts
+++ b/src/PathParticle.ts
@@ -8,6 +8,11 @@ import {Point, Texture} from "pixi.js";
  * @hidden
  */
 const helperPoint = new Point();
+/**
+ * The signature (type) of Custom path function.
+ * It takes a numbers `x`, and returns either corresponding `y` or `{x,y}`;
+ */
+export type IPathFunction = (x: number) => number | { x: number, y: number };
 
 /**
  * A hand picked list of Math functions (and a couple properties) that are
@@ -191,14 +196,17 @@ export class PathParticle extends Particle
 	 * @param extraData The extra data from the particle config.
 	 * @return The parsed extra data.
 	 */
-	public static parseData(extraData: {path:string})
+	public static parseData(extraData: {path:string | IPathFunction})
 	{
 		let output: any = {};
 		if(extraData && extraData.path)
 		{
 			try
 			{
-				output.path = parsePath(extraData.path);
+				if(typeof extraData.path === "function")
+					output.path = extraData.path;
+				else
+					output.path = parsePath(extraData.path as string);	
 			}
 			catch(e)
 			{

--- a/src/PathParticle.ts
+++ b/src/PathParticle.ts
@@ -158,8 +158,24 @@ export class PathParticle extends Particle
 			const speed = this.speedList.interpolate(lerp) * this.speedMultiplier;
 			this.movement += speed * delta;
 			//set up the helper point for rotation
-			helperPoint.x = this.movement;
-			helperPoint.y = this.path(this.movement);
+			let calculatedValue = this.path(this.movement);
+			if (calculatedValue && typeof calculatedValue.x === "number" && typeof calculatedValue.y === "number")
+			{
+				helperPoint.x = calculatedValue.x;
+				helperPoint.y = calculatedValue.y;
+			}
+			else if (typeof calculatedValue === "number") 
+			{
+				helperPoint.x = this.movement;
+				helperPoint.y = calculatedValue;
+			}
+			else
+			{
+				if(ParticleUtils.verbose)
+					console.error("PathParticle: error in parsing path expression.");
+				helperPoint.x = this.movement;
+				helperPoint.y = this.movement;
+			}
 			ParticleUtils.rotatePoint(this.initialRotation, helperPoint);
 			this.position.x = this.initialPosition.x + helperPoint.x;
 			this.position.y = this.initialPosition.y + helperPoint.y;


### PR DESCRIPTION
Provide support for custom path functions for Path particles, in two ways
  1. within `extraData.path = function(x) { return x*x; }` or
  2. `__emitter__.pathFunction = function(x) { return x*x; }`

Also, these custom path functions can control either only `y`, or both `{x, y}` values, which opens up a lot of options that allows particles to move in both x- and y-axis, against previously where we could calculate only `y` value. 

These path functions can be changed at run-time. 

@andrewstart, For more details, please check following newly added examples:  
1. **bubbleStreamCustomPath.html**
2. **bubbleStream2DPath.html**
