### PR TITLE
[wip] Add preset behavior types to BehaviorEntry

### DIFF
--- a/src/EmitterConfig.ts
+++ b/src/EmitterConfig.ts
@@ -74,7 +74,33 @@ export interface BehaviorEntry
     /**
      * The behavior type, as defined as the static `type` property of a behavior class.
      */
-    type: string;
+    type:        
+        | string
+        | 'alpha'
+        | 'alphaStatic'
+        | 'animatedRandom'
+        | 'animatedSingle'
+        | 'blendMode'
+        | 'color'
+        | 'colorStatic'
+        | 'moveAcceleration'
+        | 'movePath'
+        | 'moveSpeed'
+        | 'moveSpeedStatic'
+        | 'noRotation'
+        | 'polygonalChain'
+        | 'rect'
+        | 'rotation'
+        | 'rotationStatic'
+        | 'scale'
+        | 'scaleStatic'
+        | 'spawnBurst'
+        | 'spawnPoint'
+        | 'spawnShape'
+        | 'textureOrdered'
+        | 'textureRandom'
+        | 'textureSingle'
+        | 'torus';
     /**
      * Configuration data specific to that behavior.
      */


### PR DESCRIPTION
So that autocomplete works and users can get to creating faster without referring to docs.
Next step would be to create a map type that narrows config by behavior type.

In case behaviors can be unregistered the pr may be invalid.