### PR TITLE
Make example emitters follow mouse while button is held

### DIFF
--- a/docs/examples/js/ParticleExample.js
+++ b/docs/examples/js/ParticleExample.js
@@ -159,6 +159,30 @@
                 // Center on the stage
                 this.emitter.updateOwnerPos(window.innerWidth / 2, window.innerHeight / 2);
 
+                let isMouseDown = false;
+                canvas.addEventListener('mousedown', (e) =>
+                {
+                    if (!this.emitter) return;
+
+                    // Left click
+                    if (e.button === 0)
+                    {
+                        isMouseDown = true;
+                        this.emitter.emit = true;
+                        this.emitter.resetPositionTracking();
+                        this.emitter.updateOwnerPos(e.offsetX || e.layerX, e.offsetY || e.layerY);
+                    }
+                });
+
+                // Position the emitter to the mouse while left click is down
+                canvas.addEventListener('mousemove', (e) =>
+                {
+                    if (isMouseDown && this.emitter)
+                    {
+                        this.emitter.updateOwnerPos(e.offsetX || e.layerX, e.offsetY || e.layerY);
+                    }
+                });
+
                 // Click on the canvas to trigger
                 canvas.addEventListener('mouseup', (e) =>
                 {
@@ -186,9 +210,7 @@
                     }
                     else
                     {
-                        this.emitter.emit = true;
-                        this.emitter.resetPositionTracking();
-                        this.emitter.updateOwnerPos(e.offsetX || e.layerX, e.offsetY || e.layerY);
+                        isMouseDown = false;
                     }
                 });
 


### PR DESCRIPTION
While testing the examples I noticed that the emitters only snap to the mouse position when the left mouse button is released. I felt that it would be nicer if they continuously follow the mouse while the button is held.

Before:
![before](https://github.com/user-attachments/assets/52575a8c-2262-452e-a69a-ab4f64c35075)

After:
![after](https://github.com/user-attachments/assets/c1d79e00-3e34-4ab6-b869-e5fedcdc4308)
